### PR TITLE
Add governance infrastructure plan

### DIFF
--- a/docs/GOVERNANCE_INFRASTRUCTURE_PLAN.md
+++ b/docs/GOVERNANCE_INFRASTRUCTURE_PLAN.md
@@ -1,0 +1,112 @@
+# Governance, Validation, Contribution, and Voting Infrastructure Plan
+
+## 1. Guiding Principles
+- **Trust and Accountability:** Every interaction must be traceable without compromising participant pseudonymity. Validator and moderator actions are logged with immutable audit trails.
+- **Cited, Comprehensible Dialogue:** Claims require verifiable sources and comprehension quizzes ensure voters understand context before impacting consensus.
+- **Role Separation:** Creation, validation, moderation, and voting have distinct privileges to prevent conflicts of interest.
+- **Privacy by Design:** Personally identifiable data remains in the VC/DID broker; the application graph only stores alias identifiers, aligned with the product mission.
+
+## 2. Core Roles and Permissions
+| Role | Capabilities | Key Safeguards |
+| --- | --- | --- |
+| **Creators** | Submit topics, claims (Pro/Con), counter-arguments, and citations; respond to validator feedback. | Throttled submission quotas, citation completeness checks, and quiz history tracking. |
+| **Validators** | Review pending submissions, verify citations, administer comprehension quizzes, approve/reject claims, flag duplicates. | Blind review mode (alias-only view), conflict-of-interest declaration, minimum 2 validator approvals for high-impact claims. |
+| **Moderators** | Enforce civility policy, resolve escalations, manage role assignments, trigger appeals process. | Separate escalation queue, immutable audit log entries, rate-limited punitive actions. |
+| **Observers/Voters** | Consume debate trees, take quizzes, cast impact votes, participate in consensus polls. | Quiz gating, ZK uniqueness proofs for votes, revocation of voting rights upon quiz failure thresholds. |
+| **Stewardship Council** | Sets policy, manages validator onboarding/offboarding, tunes quiz and voting mechanics, monitors KPIs. | Quarterly rotation of chair, public meeting minutes, supermajority required for policy changes. |
+
+## 3. Governance Framework
+1. **Policy Layer**
+   - The Stewardship Council publishes policy documents (moderation guidelines, citation standards, quiz scoring thresholds) stored in versioned Git repositories.
+   - Major policy updates require: (a) draft circulation ≥14 days, (b) validator feedback session, (c) 2/3 council approval recorded in the governance log collection.
+2. **Operational Oversight**
+   - Monthly governance reviews combine Neo4j analytics (validator turnaround, quiz pass rates) with Snowflake dashboards.
+   - Automated alerts (PagerDuty/Slack) fire when KPIs breach SLA thresholds (e.g., validator backlog >24h).
+3. **Appeals & Disputes**
+   - Moderation appeals escalate to a three-person panel (council member, moderator, validator). Verdict and rationale recorded in immutable audit store.
+   - Contributors can request independent citation audits; results appended to claim node metadata as `audit_findings` with provenance.
+4. **Identity & Access Management**
+   - Auth Broker integrates with the VC/DID provider for KYC verification. Role assignments managed via attribute-based access control (ABAC) policies enforced at the API gateway.
+   - Revocation lists propagated hourly to ensure suspended users lose action privileges immediately.
+
+## 4. Validation Infrastructure
+1. **Submission Intake**
+   - Creators submit claims through Web App forms enforcing citation attachment, structured metadata, and duplicate detection (Neo4j fuzzy query).
+   - Submissions land in a `pending_claims` queue (e.g., Redis or managed queue) referenced by task IDs stored in Neo4j with status `UNDER_REVIEW`.
+2. **Validator Workflow**
+   - Validator console surfaces task queue, showing anonymized alias, claim text, citation metadata, and suggested AI highlights for speed.
+   - Validators perform checks:
+     1. Citation integrity (URL reachability, metadata match via API call to citation service).
+     2. Neutrality/duplication (graph similarity queries).
+     3. Quiz question authoring or selection from template library.
+   - Decisions recorded as `VALIDATED` or `REJECTED` edges with structured feedback. Multiple validators can append reviews; claim publishes only after required approvals met.
+3. **Quality Assurance**
+   - Weekly spot audits by senior validators sample ≥5% of approvals. Findings feed into validator performance scores.
+   - AI-assisted monitoring flags anomalous approval rates or rapid-fire approvals for manual review.
+4. **Tooling & Monitoring**
+   - Metrics: average review time, rejection reasons, quiz difficulty distribution.
+   - Logs: stored centrally (e.g., ELK or OpenSearch) with structured event schemas; validator actions tagged with DID alias.
+
+## 5. Contribution Workflow
+1. **Topic Lifecycle**
+   - Council or moderators seed topics with prompts; Creators propose topics subject to council approval.
+   - Each topic node maintains status (`DRAFT`, `ACTIVE`, `ARCHIVED`). Archival requires moderator + council sign-off.
+2. **Claim Authoring**
+   - Creators draft claims with required citation entries (author, publication, date, URL). Front-end enforces citation completeness via form validation.
+   - AI assistant suggests citations; creators must confirm and provide human justification stored as `source_rationale`.
+3. **Iteration & Feedback**
+   - Validators can request revisions; claim re-enters queue with version increment. All revisions tracked via Neo4j version nodes or property history.
+   - Creators receive structured validator feedback via notifications; responses appended to claim discussion thread.
+4. **Publication**
+   - Once published, claim enters debate tree. Subsequent edits require new validator review and maintain version history for transparency.
+
+## 6. Voting and Consensus Mechanics
+1. **Quiz Gating**
+   - Prior to voting, users must pass topic-specific comprehension quizzes authored during validation.
+   - Quiz results stored with timestamp and version; failures trigger cooldowns. Passing unlocks voting for 30 days or until topic updates require re-quiz.
+2. **Impact Voting**
+   - Voters assign impact scores (e.g., -3 to +3). API verifies:
+     - Quiz completion token validity.
+     - Semaphore-like ZK proof for uniqueness per topic/claim.
+     - Rate limits (one impact vote per claim per 24h).
+   - Votes recorded as `VOTED` relations with weight, proof hash, and optional rationale.
+3. **Consensus Polls**
+   - Periodic polls summarize debate position. Participation requires active quiz token and no outstanding moderation flags.
+   - Results published with anonymized metrics and confidence intervals sourced from Snowflake analytics.
+4. **Fraud Prevention & Auditing**
+   - Continuous anomaly detection on voting patterns (e.g., sudden spikes tied to single IP ranges as seen through privacy-preserving aggregation).
+   - Identity broker can revoke voting credentials; API respects revocation immediately.
+
+## 7. Data Management & Transparency
+- **Neo4j Graph:** Stores structured debate data, validation status, vote relationships, and audit pointers.
+- **Snowflake Exporter:** Generates daily sanitized datasets for external review; includes governance actions, validator metrics, and vote aggregates.
+- **Audit Logs:** Append-only storage (e.g., AWS QLDB or immutably versioned S3) capturing all governance, validation, and voting events.
+- **Public Transparency Portal:** Web App module exposing policy documents, validator performance dashboards, and appeal outcomes.
+
+## 8. Implementation Roadmap
+1. **Phase 0 – Foundations**
+   - Finalize policy baseline, steward council charter, and IAM design.
+   - Implement VC/DID integration and ABAC enforcement in API gateway.
+2. **Phase 1 – Validation & Contribution MVP**
+   - Deliver validator console, submission queue, audit logging, and quiz authoring.
+   - Launch creator onboarding and AI citation assistance.
+3. **Phase 2 – Voting & Consensus**
+   - Integrate ZK proof verification, quiz gating workflows, and impact voting UI.
+   - Deploy anomaly detection pipelines and consensus polling analytics.
+4. **Phase 3 – Transparency & Governance Scaling**
+   - Roll out public dashboards, policy versioning portal, and advanced audit tooling.
+   - Establish continuous improvement cadence with KPI reviews and community feedback loops.
+
+## 9. Success Metrics Alignment
+- ≥95% validated citations maintained through validator SLA monitoring.
+- ≥80% quiz-to-vote conversion supported by smooth gating workflows.
+- <4h median validator turnaround ensured by queue analytics and staffing policies.
+- ≥70% first-attempt quiz pass rate driven by quality assurance and feedback loops.
+- ≥99% reliability of daily exports via monitored Snowflake pipeline.
+
+## 10. Open Questions & Next Steps
+- Define exact quorum rules for validator approvals by claim type (e.g., 2 for standard, 3 for high-impact).
+- Determine storage choice for immutable audits (QLDB vs. Chronicle vs. custom).
+- Finalize appeal panel selection algorithm to avoid conflicts of interest.
+- Validate legal requirements for transparent publication of council minutes and audit summaries.
+- Prototype the ZK uniqueness flow end-to-end with Auth Broker before public launch.


### PR DESCRIPTION
## Summary
- add a comprehensive governance, validation, contribution, and voting infrastructure plan grounded in the platform mission
- document role responsibilities, operational controls, workflows, and implementation roadmap for debate governance

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68ca29918104832e8bbc36cfe1ff5c11